### PR TITLE
Add app_path function for cross-platform pathing

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -9,9 +9,23 @@ from input_handlers import handle_keys, handle_mouse
 from loader_functions.initialize_new_game import Constants, get_game_variables
 from render_functions import clear_all, render_all
 
+from os import path
+import sys
+
+# Get the current location of the bundled App (a la PyInstaller)
+app_dir = getattr(sys, '_MEIPASS', path.abspath(path.dirname(__file__)))
+
+
+def app_path(*local_path_segments):
+    # Account for varying slash marks across filesystems & OSes
+    return path.join(app_dir, *local_path_segments)
+
+arial_font_path = app_path('assets', 'images', 'arial10x10.png')
+
+
 def main():
 
-    libtcod.console_set_custom_font('assets/images/arial10x10.png', libtcod.FONT_TYPE_GREYSCALE | libtcod.FONT_LAYOUT_TCOD)
+    libtcod.console_set_custom_font(arial_font_path, libtcod.FONT_TYPE_GREYSCALE | libtcod.FONT_LAYOUT_TCOD)
 
     libtcod.console_init_root(Constants.screen_width, Constants.screen_height, 'Rogue Possession', False)
 


### PR DESCRIPTION
PyInstaller mostly works, but we need to make it possible
for the "app-ified" game to locate the assets (like our
Arial font) relative to itself - PyInstaller adds special
`sys` attributes to help with this.

(And we need to express that path using the appropriate
path separation characters for the OS we're running on!)

This seems to fix it for MacOS, hopefully also for Windows?
(I'll confirm later tonight)

Not sure if there's a better name for this function, or a
better place to put it yet...